### PR TITLE
Add `ThrowExceptionOnFailurePlugin` to standardise error behaviour with other mailers

### DIFF
--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -9,6 +9,7 @@ use Craft;
 use craft\behaviors\EnvAttributeParserBehavior;
 use craft\mail\transportadapters\BaseTransportAdapter;
 use Postmark\Transport;
+use Postmark\ThrowExceptionOnFailurePlugin;
 
 /**
  * Adapter represents the Postmark mail adapter.
@@ -88,9 +89,11 @@ class Adapter extends BaseTransportAdapter
      */
     public function defineTransport()
     {
-        return [
-            'class' => Transport::class,
-            'constructArgs' => [Craft::parseEnv($this->token), ['X-PM-Message-Stream' => Craft::parseEnv($this->messageStream)]],
-        ];
+        $transport = new Transport(Craft::parseEnv($this->token), ['X-PM-Message-Stream' => Craft::parseEnv($this->messageStream)]);
+        
+        // Throw an error on message failure
+        $transport->registerPlugin(new ThrowExceptionOnFailurePlugin());
+
+        return $transport;
     }
 }


### PR DESCRIPTION
According to their [own docs](https://github.com/ActiveCampaign/swiftmailer-postmark#3-throw-exceptions-on-postmark-api-errors) this is how you can set this adapter to throw an error when it fails. Currently, we get no feedback on when email failure happens.

When an error occurs, the mailer returns `false` which is fine, but thanks to the [PR](https://github.com/craftcms/cms/pull/8091) in Craft 3.7, we can capture error messages about a failed email if an exception is thrown.

This would also fix https://github.com/craftcms/postmark/issues/19

This may not be applicable for Craft 4 due to the mailer switch away from SwiftMailer.